### PR TITLE
Fix project.pbxproj file merge issue

### DIFF
--- a/Dxtr.xcodeproj/project.pbxproj
+++ b/Dxtr.xcodeproj/project.pbxproj
@@ -7,32 +7,26 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1D7B186D1ABCCBD500DD1632 /* _FailedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B186C1ABCCBD500DD1632 /* _FailedUpload.swift */; };
-		1D7B18721ABCCBDD00DD1632 /* FailedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B18711ABCCBDD00DD1632 /* FailedUpload.swift */; };
-		1D7B18741ABCF45100DD1632 /* ChartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B18731ABCF45100DD1632 /* ChartViewController.swift */; };
-		1D7B18761ABCF4C700DD1632 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B18751ABCF4C700DD1632 /* SettingsManager.swift */; };
-		1D7B18781ABCF4DA00DD1632 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18771ABCF4DA00DD1632 /* Settings.bundle */; };
-		1D7B18871ABD2F7700DD1632 /* XCGLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD153501A8179D0003E7CFD /* XCGLogger.framework */; };
-		1D7B18881ABD2F7700DD1632 /* XCGLogger.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD153501A8179D0003E7CFD /* XCGLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		1D7B188C1ABD30DD00DD1632 /* FailedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B18711ABCCBDD00DD1632 /* FailedUpload.swift */; };
-		1D7B188D1ABD30E100DD1632 /* _FailedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B186C1ABCCBD500DD1632 /* _FailedUpload.swift */; };
-		1D7B188E1ABD30E800DD1632 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B18751ABCF4C700DD1632 /* SettingsManager.swift */; };
-		1D7B188F1ABD30F500DD1632 /* ChartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B18731ABCF45100DD1632 /* ChartViewController.swift */; };
-		1D7B18911ABE88A000DD1632 /* StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B18901ABE88A000DD1632 /* StateManager.swift */; };
-		1D7B18921ABE88A000DD1632 /* StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B18901ABE88A000DD1632 /* StateManager.swift */; };
-		1D7B18981ABF443700DD1632 /* chart.css in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18941ABF443700DD1632 /* chart.css */; };
-		1D7B18991ABF443700DD1632 /* chart.css in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18941ABF443700DD1632 /* chart.css */; };
-		1D7B189A1ABF443700DD1632 /* chart.html in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18951ABF443700DD1632 /* chart.html */; };
-		1D7B189B1ABF443700DD1632 /* chart.html in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18951ABF443700DD1632 /* chart.html */; };
-		1D7B189C1ABF443700DD1632 /* client.js in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18961ABF443700DD1632 /* client.js */; };
-		1D7B189D1ABF443700DD1632 /* client.js in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18961ABF443700DD1632 /* client.js */; };
-		1D7B189E1ABF443700DD1632 /* d3.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18971ABF443700DD1632 /* d3.min.js */; };
-		1D7B189F1ABF443700DD1632 /* d3.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 1D7B18971ABF443700DD1632 /* d3.min.js */; };
-		1DD153611A8193CA003E7CFD /* NightscoutUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD153601A8193CA003E7CFD /* NightscoutUploader.swift */; };
-		215C6EE6E3F65D14315957DD /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE74BA18BFC6C534602170C6 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		4300FCD11A82C3DB00CC8CE1 /* default_background.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 4300FCD01A82C3DB00CC8CE1 /* default_background.jpeg */; };
-		4300FCD41A82C75E00CC8CE1 /* StartSensorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4300FCD31A82C75E00CC8CE1 /* StartSensorViewController.swift */; };
-		43027B171A7FBD1C00DE47F8 /* TestRawData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43027B161A7FBD1C00DE47F8 /* TestRawData.swift */; };
+		1DCAA6531ABF4EA000A3F2CC /* chart.css in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA64E1ABF4EA000A3F2CC /* chart.css */; };
+		1DCAA6541ABF4EA000A3F2CC /* chart.css in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA64E1ABF4EA000A3F2CC /* chart.css */; };
+		1DCAA6551ABF4EA000A3F2CC /* chart.html in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA64F1ABF4EA000A3F2CC /* chart.html */; };
+		1DCAA6561ABF4EA000A3F2CC /* chart.html in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA64F1ABF4EA000A3F2CC /* chart.html */; };
+		1DCAA6571ABF4EA000A3F2CC /* client.js in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA6501ABF4EA000A3F2CC /* client.js */; };
+		1DCAA6581ABF4EA000A3F2CC /* client.js in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA6501ABF4EA000A3F2CC /* client.js */; };
+		1DCAA6591ABF4EA000A3F2CC /* d3.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA6511ABF4EA000A3F2CC /* d3.min.js */; };
+		1DCAA65A1ABF4EA000A3F2CC /* d3.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA6511ABF4EA000A3F2CC /* d3.min.js */; };
+		1DCAA65B1ABF4EA000A3F2CC /* jquery.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA6521ABF4EA000A3F2CC /* jquery.min.js */; };
+		1DCAA65C1ABF4EA000A3F2CC /* jquery.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 1DCAA6521ABF4EA000A3F2CC /* jquery.min.js */; };
+		1DCAA65E1ABF4EB000A3F2CC /* ChartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA65D1ABF4EB000A3F2CC /* ChartViewController.swift */; };
+		1DCAA65F1ABF4EB000A3F2CC /* ChartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA65D1ABF4EB000A3F2CC /* ChartViewController.swift */; };
+		1DCAA6621ABF4ECA00A3F2CC /* _FailedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA6601ABF4ECA00A3F2CC /* _FailedUpload.swift */; };
+		1DCAA6631ABF4ECA00A3F2CC /* _FailedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA6601ABF4ECA00A3F2CC /* _FailedUpload.swift */; };
+		1DCAA6641ABF4ECA00A3F2CC /* FailedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA6611ABF4ECA00A3F2CC /* FailedUpload.swift */; };
+		1DCAA6651ABF4ECA00A3F2CC /* FailedUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA6611ABF4ECA00A3F2CC /* FailedUpload.swift */; };
+		1DCAA6681ABF4EEF00A3F2CC /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA6661ABF4EEF00A3F2CC /* SettingsManager.swift */; };
+		1DCAA6691ABF4EEF00A3F2CC /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA6661ABF4EEF00A3F2CC /* SettingsManager.swift */; };
+		1DCAA66A1ABF4EEF00A3F2CC /* StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA6671ABF4EEF00A3F2CC /* StateManager.swift */; };
+		1DCAA66B1ABF4EEF00A3F2CC /* StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCAA6671ABF4EEF00A3F2CC /* StateManager.swift */; };
 		1DD153611A8193CA003E7CFD /* NightscoutUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD153601A8193CA003E7CFD /* NightscoutUploader.swift */; };
 		215C6EE6E3F65D14315957DD /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE74BA18BFC6C534602170C6 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		4300FCD11A82C3DB00CC8CE1 /* default_background.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 4300FCD01A82C3DB00CC8CE1 /* default_background.jpeg */; };
@@ -50,10 +44,6 @@
 		434534AB1A751E70000D591E /* Calibration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434534A51A751E70000D591E /* Calibration.swift */; };
 		434534AC1A751E70000D591E /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434534A61A751E70000D591E /* Sensor.swift */; };
 		435C921C1A6F9C9B00807847 /* TransmitterData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435C921A1A6F9C9B00807847 /* TransmitterData.swift */; };
-		438FFC921A7EBD1D0025D655 /* SwiftOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438FFC911A7EBD1D0025D655 /* SwiftOverlays.swift */; };
-		43BBDF9A1A642D850006B61F /* BTDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBDF981A642D850006B61F /* BTDiscovery.swift */; };
-		43BBDF9B1A642D850006B61F /* BTService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBDF991A642D850006B61F /* BTService.swift */; };
-		43BBDF9E1A642DC50006B61F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBDF9D1A642DC40006B61F /* Constants.swift */; };
 		4388DE711ABC207200DB2F30 /* XCGLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43CFB80A1AB89B4500C70423 /* XCGLogger.framework */; };
 		43BBDF9A1A642D850006B61F /* BTDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBDF981A642D850006B61F /* BTDiscovery.swift */; };
 		43BBDF9B1A642D850006B61F /* BTService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBDF991A642D850006B61F /* BTService.swift */; };
@@ -83,7 +73,6 @@
 		43CFB7E71AB73D9F00C70423 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 43E5362E1A62CE480037EED0 /* LaunchScreen.xib */; };
 		43CFB7E81AB73DA300C70423 /* default_background.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 4300FCD01A82C3DB00CC8CE1 /* default_background.jpeg */; };
 		43CFB7E91AB73DAB00C70423 /* B68UIFloatLabelTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D890BB1A891EBA009C9F40 /* B68UIFloatLabelTextField.swift */; };
-		43CFB7EA1AB73DB400C70423 /* SwiftOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438FFC911A7EBD1D0025D655 /* SwiftOverlays.swift */; };
 		43CFB7F21AB76E5D00C70423 /* SensorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CFB7F11AB76E5D00C70423 /* SensorTests.swift */; };
 		43CFB8131AB8C05300C70423 /* SwiftOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CFB8121AB8C05300C70423 /* SwiftOverlays.swift */; };
 		43CFB8141AB8C05300C70423 /* SwiftOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CFB8121AB8C05300C70423 /* SwiftOverlays.swift */; };
@@ -101,9 +90,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		1D7B18891ABD2F7700DD1632 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 438FFC851A7EBC730025D655 /* XCGLogger.xcodeproj */;
 		4304DFCA1ABC879400856AD8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 43CFB8011AB89B4500C70423 /* XCGLogger.xcodeproj */;
@@ -111,9 +97,6 @@
 			remoteGlobalIDString = 55E3EE4419D76F280068C3A7;
 			remoteInfo = "XCGLogger (iOS)";
 		};
-		1DD1534F1A8179D0003E7CFD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 438FFC851A7EBC730025D655 /* XCGLogger.xcodeproj */;
 		43CFB8091AB89B4500C70423 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 43CFB8011AB89B4500C70423 /* XCGLogger.xcodeproj */;
@@ -121,9 +104,6 @@
 			remoteGlobalIDString = 55E3EE4519D76F280068C3A7;
 			remoteInfo = "XCGLogger (iOS)";
 		};
-		1DD153511A8179D0003E7CFD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 438FFC851A7EBC730025D655 /* XCGLogger.xcodeproj */;
 		43CFB80B1AB89B4500C70423 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 43CFB8011AB89B4500C70423 /* XCGLogger.xcodeproj */;
@@ -131,9 +111,6 @@
 			remoteGlobalIDString = 554DF41719D76FE7005708BE;
 			remoteInfo = "XCGLogger (OS X)";
 		};
-		1DD153531A8179D0003E7CFD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 438FFC851A7EBC730025D655 /* XCGLogger.xcodeproj */;
 		43CFB80D1AB89B4500C70423 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 43CFB8011AB89B4500C70423 /* XCGLogger.xcodeproj */;
@@ -151,17 +128,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		1D7B188B1ABD2F7700DD1632 /* Embed Frameworks */ = {
-		1D8834131AAD4F1E00DA685B /* Embed Frameworks */ = {
 		4304DFD01ABC879500856AD8 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				1D7B18881ABD2F7700DD1632 /* XCGLogger.framework in Embed Frameworks */,
-				1D8834101AAD4F1E00DA685B /* CryptoSwift.framework in Embed Frameworks */,
-				1D8834151AAD4F5B00DA685B /* XCGLogger.framework in Embed Frameworks */,
 				4304DFC91ABC879400856AD8 /* XCGLogger.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -182,18 +154,16 @@
 
 /* Begin PBXFileReference section */
 		0AFAD76CD12C94905DFF9A02 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		1D7B186C1ABCCBD500DD1632 /* _FailedUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _FailedUpload.swift; sourceTree = "<group>"; };
-		1D7B18711ABCCBDD00DD1632 /* FailedUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FailedUpload.swift; sourceTree = "<group>"; };
-		1D7B18731ABCF45100DD1632 /* ChartViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartViewController.swift; sourceTree = "<group>"; };
-		1D7B18751ABCF4C700DD1632 /* SettingsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
-		1D7B18771ABCF4DA00DD1632 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
-		1D7B18901ABE88A000DD1632 /* StateManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateManager.swift; sourceTree = "<group>"; };
-		1D7B18941ABF443700DD1632 /* chart.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = chart.css; sourceTree = "<group>"; };
-		1D7B18951ABF443700DD1632 /* chart.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = chart.html; sourceTree = "<group>"; };
-		1D7B18961ABF443700DD1632 /* client.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = client.js; sourceTree = "<group>"; };
-		1D7B18971ABF443700DD1632 /* d3.min.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = d3.min.js; sourceTree = "<group>"; };
-		1DD153601A8193CA003E7CFD /* NightscoutUploader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NightscoutUploader.swift; sourceTree = "<group>"; };
-		1DD153621A81A38B003E7CFD /* CryptoSwift.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CryptoSwift.xcodeproj; path = CryptoSwift/CryptoSwift.xcodeproj; sourceTree = "<group>"; };
+		1DCAA64E1ABF4EA000A3F2CC /* chart.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = chart.css; sourceTree = "<group>"; };
+		1DCAA64F1ABF4EA000A3F2CC /* chart.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = chart.html; sourceTree = "<group>"; };
+		1DCAA6501ABF4EA000A3F2CC /* client.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = client.js; sourceTree = "<group>"; };
+		1DCAA6511ABF4EA000A3F2CC /* d3.min.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = d3.min.js; sourceTree = "<group>"; };
+		1DCAA6521ABF4EA000A3F2CC /* jquery.min.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = jquery.min.js; sourceTree = "<group>"; };
+		1DCAA65D1ABF4EB000A3F2CC /* ChartViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartViewController.swift; sourceTree = "<group>"; };
+		1DCAA6601ABF4ECA00A3F2CC /* _FailedUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _FailedUpload.swift; sourceTree = "<group>"; };
+		1DCAA6611ABF4ECA00A3F2CC /* FailedUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FailedUpload.swift; sourceTree = "<group>"; };
+		1DCAA6661ABF4EEF00A3F2CC /* SettingsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
+		1DCAA6671ABF4EEF00A3F2CC /* StateManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateManager.swift; sourceTree = "<group>"; };
 		1DD153601A8193CA003E7CFD /* NightscoutUploader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NightscoutUploader.swift; sourceTree = "<group>"; };
 		4300FCD01A82C3DB00CC8CE1 /* default_background.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = default_background.jpeg; sourceTree = "<group>"; };
 		4300FCD31A82C75E00CC8CE1 /* StartSensorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartSensorViewController.swift; sourceTree = "<group>"; };
@@ -208,11 +178,6 @@
 		434534A51A751E70000D591E /* Calibration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Calibration.swift; sourceTree = "<group>"; };
 		434534A61A751E70000D591E /* Sensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sensor.swift; sourceTree = "<group>"; };
 		435C921A1A6F9C9B00807847 /* TransmitterData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransmitterData.swift; sourceTree = "<group>"; };
-		438FFC851A7EBC730025D655 /* XCGLogger.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = XCGLogger.xcodeproj; path = "XCGLogger-master/XCGLogger/Library/XCGLogger.xcodeproj"; sourceTree = SOURCE_ROOT; };
-		438FFC911A7EBD1D0025D655 /* SwiftOverlays.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftOverlays.swift; path = "SwiftOverlays-master/SwiftOverlays/SwiftOverlays.swift"; sourceTree = SOURCE_ROOT; };
-		43BBDF981A642D850006B61F /* BTDiscovery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTDiscovery.swift; sourceTree = "<group>"; };
-		43BBDF991A642D850006B61F /* BTService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTService.swift; sourceTree = "<group>"; };
-		43BBDF9D1A642DC40006B61F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		43BBDF981A642D850006B61F /* BTDiscovery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTDiscovery.swift; sourceTree = "<group>"; };
 		43BBDF991A642D850006B61F /* BTService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTService.swift; sourceTree = "<group>"; };
 		43BBDF9D1A642DC40006B61F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -245,7 +210,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B44A2CAB3799B1C9D5A72105 /* Pods.framework in Frameworks */,
-				1D7B18871ABD2F7700DD1632 /* XCGLogger.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,30 +225,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1D7B18931ABF440D00DD1632 /* Chart */ = {
+		1DCAA64B1ABF4E8500A3F2CC /* Chart */ = {
 			isa = PBXGroup;
 			children = (
-				1D7B18941ABF443700DD1632 /* chart.css */,
-				1D7B18951ABF443700DD1632 /* chart.html */,
-				1D7B18961ABF443700DD1632 /* client.js */,
-				1D7B18971ABF443700DD1632 /* d3.min.js */,
+				1DCAA64E1ABF4EA000A3F2CC /* chart.css */,
+				1DCAA64F1ABF4EA000A3F2CC /* chart.html */,
+				1DCAA6501ABF4EA000A3F2CC /* client.js */,
+				1DCAA6511ABF4EA000A3F2CC /* d3.min.js */,
+				1DCAA6521ABF4EA000A3F2CC /* jquery.min.js */,
 			);
 			name = Chart;
 			sourceTree = "<group>";
 		};
-		1DD1534A1A8179D0003E7CFD /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				1DD153501A8179D0003E7CFD /* XCGLogger.framework */,
-				1DD153521A8179D0003E7CFD /* XCGLogger.framework */,
-				1DD153541A8179D0003E7CFD /* XCGLoggerTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		4300FCC61A82935000CC8CE1 /* Views */ = {
-			isa = PBXGroup;
-			children = (
 		4300FCC61A82935000CC8CE1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -300,8 +252,8 @@
 				4300FCD31A82C75E00CC8CE1 /* StartSensorViewController.swift */,
 				43D890C21A8921A6009C9F40 /* AddBGReadingViewController.swift */,
 				432771B51A8A8BC900F42162 /* AddDoubleCalibrationViewController.swift */,
+				1DCAA65D1ABF4EB000A3F2CC /* ChartViewController.swift */,
 				432771BE1A8AA47D00F42162 /* EulaViewController.swift */,
-				1D7B18731ABCF45100DD1632 /* ChartViewController.swift */,
 			);
 			name = ViewController;
 			sourceTree = "<group>";
@@ -310,8 +262,6 @@
 			isa = PBXGroup;
 			children = (
 				43D890BB1A891EBA009C9F40 /* B68UIFloatLabelTextField.swift */,
-				438FFC911A7EBD1D0025D655 /* SwiftOverlays.swift */,
-				438FFC851A7EBC730025D655 /* XCGLogger.xcodeproj */,
 				43CFB8121AB8C05300C70423 /* SwiftOverlays.swift */,
 				43CFB8011AB89B4500C70423 /* XCGLogger.xcodeproj */,
 			);
@@ -323,12 +273,12 @@
 			children = (
 				4324ED861A812DDA0002BEE6 /* _BGReading.swift */,
 				4324ED871A812DDA0002BEE6 /* _Calibration.swift */,
-				1D7B186C1ABCCBD500DD1632 /* _FailedUpload.swift */,
+				1DCAA6601ABF4ECA00A3F2CC /* _FailedUpload.swift */,
 				4324ED881A812DDA0002BEE6 /* _Sensor.swift */,
 				4324ED891A812DDA0002BEE6 /* _TransmitterData.swift */,
 				434534A41A751E70000D591E /* BGReading.swift */,
 				434534A51A751E70000D591E /* Calibration.swift */,
-				1D7B18711ABCCBDD00DD1632 /* FailedUpload.swift */,
+				1DCAA6611ABF4ECA00A3F2CC /* FailedUpload.swift */,
 				434534A61A751E70000D591E /* Sensor.swift */,
 				435C921A1A6F9C9B00807847 /* TransmitterData.swift */,
 			);
@@ -367,7 +317,6 @@
 		43E536171A62CE480037EED0 = {
 			isa = PBXGroup;
 			children = (
-				1DD153621A81A38B003E7CFD /* CryptoSwift.xcodeproj */,
 				43CFB7F81AB7724B00C70423 /* .travis.yml */,
 				43E536221A62CE480037EED0 /* Dxtr */,
 				43E536381A62CE480037EED0 /* DxtrTests */,
@@ -389,19 +338,14 @@
 		43E536221A62CE480037EED0 /* Dxtr */ = {
 			isa = PBXGroup;
 			children = (
-				43BBDF9D1A642DC40006B61F /* Constants.swift */,
 				43E536251A62CE480037EED0 /* AppDelegate.swift */,
+				43BBDF9D1A642DC40006B61F /* Constants.swift */,
+				1DD153601A8193CA003E7CFD /* NightscoutUploader.swift */,
+				1DCAA6661ABF4EEF00A3F2CC /* SettingsManager.swift */,
+				1DCAA6671ABF4EEF00A3F2CC /* StateManager.swift */,
 				4300FCC61A82935000CC8CE1 /* Views */,
 				43BBDF9C1A642D910006B61F /* BluetoothStack */,
-				1D7B18931ABF440D00DD1632 /* Chart */,
-				1DD153601A8193CA003E7CFD /* NightscoutUploader.swift */,
-				1D7B18751ABCF4C700DD1632 /* SettingsManager.swift */,
-				1D7B18901ABE88A000DD1632 /* StateManager.swift */,
-				1D7B18771ABCF4DA00DD1632 /* Settings.bundle */,
-				4300FCD21A82C72A00CC8CE1 /* ViewController */,
-				435C92181A6F9B1B00807847 /* ModelObjects */,
-				43DF0D011A6D969600686779 /* Model */,
-				1D4A37781A95114400F21868 /* Chart Resources */,
+				1DCAA64B1ABF4E8500A3F2CC /* Chart */,
 				4300FCD21A82C72A00CC8CE1 /* ViewController */,
 				435C92181A6F9B1B00807847 /* ModelObjects */,
 				43DF0D011A6D969600686779 /* Model */,
@@ -474,16 +418,11 @@
 				43E5361E1A62CE480037EED0 /* Resources */,
 				6AC7309B179A3963E7ABBDB6 /* Embed Pods Frameworks */,
 				007C32A469EF957452E5B03E /* Copy Pods Resources */,
-				1D7B188B1ABD2F7700DD1632 /* Embed Frameworks */,
-				1D8834131AAD4F1E00DA685B /* Embed Frameworks */,
 				4304DFD01ABC879500856AD8 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				1D7B188A1ABD2F7700DD1632 /* PBXTargetDependency */,
-				1D8834121AAD4F1E00DA685B /* PBXTargetDependency */,
-				1D8834171AAD4F5B00DA685B /* PBXTargetDependency */,
 				4304DFCB1ABC879400856AD8 /* PBXTargetDependency */,
 			);
 			name = Dxtr;
@@ -495,10 +434,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 43E536421A62CE480037EED0 /* Build configuration list for PBXNativeTarget "DxtrTests" */;
 			buildPhases = (
-				B3956779AFC468B02C25C3B5 /* Check Pods Manifest.lock */,
-				43E536311A62CE480037EED0 /* Sources */,
-				43E536321A62CE480037EED0 /* Frameworks */,
-				43E536331A62CE480037EED0 /* Resources */,
 				4306697B1ABC262F00F5A7C0 /* Copy Frameworks */,
 				B3956779AFC468B02C25C3B5 /* Check Pods Manifest.lock */,
 				43E536311A62CE480037EED0 /* Sources */,
@@ -533,11 +468,6 @@
 					43E536341A62CE480037EED0 = {
 						CreatedOnToolsVersion = 6.1.1;
 						DevelopmentTeam = L57T999M9X;
-						DevelopmentTeam = YV6CG57Z4A;
-					};
-					43E536341A62CE480037EED0 = {
-						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = YV6CG57Z4A;
 						TestTargetID = 43E5361F1A62CE480037EED0;
 					};
 				};
@@ -555,8 +485,6 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 1DD1534A1A8179D0003E7CFD /* Products */;
-					ProjectRef = 438FFC851A7EBC730025D655 /* XCGLogger.xcodeproj */;
 					ProductGroup = 43CFB8021AB89B4500C70423 /* Products */;
 					ProjectRef = 43CFB8011AB89B4500C70423 /* XCGLogger.xcodeproj */;
 				},
@@ -570,39 +498,6 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		1DD153501A8179D0003E7CFD /* XCGLogger.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = XCGLogger.framework;
-			remoteRef = 1DD1534F1A8179D0003E7CFD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		1DD153521A8179D0003E7CFD /* XCGLogger.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = XCGLogger.framework;
-			remoteRef = 1DD153511A8179D0003E7CFD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		1DD153541A8179D0003E7CFD /* XCGLoggerTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = XCGLoggerTests.xctest;
-			remoteRef = 1DD153531A8179D0003E7CFD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		1DD153681A81A38B003E7CFD /* CryptoSwift.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = CryptoSwift.framework;
-			remoteRef = 1DD153671A81A38B003E7CFD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		1DD1536A1A81A38B003E7CFD /* CryptoSwiftTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CryptoSwiftTests.xctest;
-			remoteRef = 1DD153691A81A38B003E7CFD /* PBXContainerItemProxy */;
 		43CFB80A1AB89B4500C70423 /* XCGLogger.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -631,19 +526,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1D7B18981ABF443700DD1632 /* chart.css in Resources */,
 				43E5362B1A62CE480037EED0 /* Main.storyboard in Resources */,
-				43E536301A62CE480037EED0 /* LaunchScreen.xib in Resources */,
-				1D7B189E1ABF443700DD1632 /* d3.min.js in Resources */,
-				1D7B189C1ABF443700DD1632 /* client.js in Resources */,
-				1D7B18781ABCF4DA00DD1632 /* Settings.bundle in Resources */,
-				1D7B189A1ABF443700DD1632 /* chart.html in Resources */,
-				1D4A37821A95295C00F21868 /* client.js in Resources */,
-				1D4A377E1A9528C300F21868 /* chart.css in Resources */,
-				1D4A377C1A9528C300F21868 /* d3.min.js in Resources */,
-				43E5362B1A62CE480037EED0 /* Main.storyboard in Resources */,
+				1DCAA65B1ABF4EA000A3F2CC /* jquery.min.js in Resources */,
 				43E536301A62CE480037EED0 /* LaunchScreen.xib in Resources */,
 				43E5362D1A62CE480037EED0 /* Images.xcassets in Resources */,
+				1DCAA6551ABF4EA000A3F2CC /* chart.html in Resources */,
+				1DCAA6531ABF4EA000A3F2CC /* chart.css in Resources */,
+				1DCAA6591ABF4EA000A3F2CC /* d3.min.js in Resources */,
+				1DCAA6571ABF4EA000A3F2CC /* client.js in Resources */,
 				4300FCD11A82C3DB00CC8CE1 /* default_background.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -653,12 +543,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				43CFB7D31AB73D5E00C70423 /* Main.storyboard in Resources */,
+				1DCAA65C1ABF4EA000A3F2CC /* jquery.min.js in Resources */,
 				43CFB7E71AB73D9F00C70423 /* LaunchScreen.xib in Resources */,
 				43CFB7E61AB73D9700C70423 /* Images.xcassets in Resources */,
-				1D7B189B1ABF443700DD1632 /* chart.html in Resources */,
-				1D7B18991ABF443700DD1632 /* chart.css in Resources */,
-				1D7B189F1ABF443700DD1632 /* d3.min.js in Resources */,
-				1D7B189D1ABF443700DD1632 /* client.js in Resources */,
+				1DCAA6561ABF4EA000A3F2CC /* chart.html in Resources */,
+				1DCAA6541ABF4EA000A3F2CC /* chart.css in Resources */,
+				1DCAA65A1ABF4EA000A3F2CC /* d3.min.js in Resources */,
+				1DCAA6581ABF4EA000A3F2CC /* client.js in Resources */,
 				43CFB7E81AB73DA300C70423 /* default_background.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -805,16 +696,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43D890C31A8921A6009C9F40 /* AddBGReadingViewController.swift in Sources */,
-				4324ED8B1A812DDA0002BEE6 /* _Calibration.swift in Sources */,
-				4324ED8C1A812DDA0002BEE6 /* _Sensor.swift in Sources */,
-				438FFC921A7EBD1D0025D655 /* SwiftOverlays.swift in Sources */,
-				1D3869F21A86F2A6008EF20E /* _FailedUpload.swift in Sources */,
 				43CFB8131AB8C05300C70423 /* SwiftOverlays.swift in Sources */,
 				43D890C31A8921A6009C9F40 /* AddBGReadingViewController.swift in Sources */,
 				4324ED8B1A812DDA0002BEE6 /* _Calibration.swift in Sources */,
 				4324ED8C1A812DDA0002BEE6 /* _Sensor.swift in Sources */,
 				43027B171A7FBD1C00DE47F8 /* TestRawData.swift in Sources */,
+				1DCAA65E1ABF4EB000A3F2CC /* ChartViewController.swift in Sources */,
 				434534AC1A751E70000D591E /* Sensor.swift in Sources */,
 				432771BF1A8AA47D00F42162 /* EulaViewController.swift in Sources */,
 				43BBDF9E1A642DC50006B61F /* Constants.swift in Sources */,
@@ -822,14 +709,13 @@
 				43E536281A62CE480037EED0 /* MasterViewController.swift in Sources */,
 				4324ED8D1A812DDA0002BEE6 /* _TransmitterData.swift in Sources */,
 				434534AB1A751E70000D591E /* Calibration.swift in Sources */,
-				1D7B18721ABCCBDD00DD1632 /* FailedUpload.swift in Sources */,
+				1DCAA6621ABF4ECA00A3F2CC /* _FailedUpload.swift in Sources */,
 				43BBDF9B1A642D850006B61F /* BTService.swift in Sources */,
 				432771B61A8A8BC900F42162 /* AddDoubleCalibrationViewController.swift in Sources */,
 				4324ED8A1A812DDA0002BEE6 /* _BGReading.swift in Sources */,
+				1DCAA66A1ABF4EEF00A3F2CC /* StateManager.swift in Sources */,
+				1DCAA6681ABF4EEF00A3F2CC /* SettingsManager.swift in Sources */,
 				43DF0D061A6D96B700686779 /* dxtrDBModel.xcdatamodeld in Sources */,
-				1D7B18911ABE88A000DD1632 /* StateManager.swift in Sources */,
-				1D7B18761ABCF4C700DD1632 /* SettingsManager.swift in Sources */,
-				1D7B18741ABCF45100DD1632 /* ChartViewController.swift in Sources */,
 				43DF0D081A6D9ADD00686779 /* DxtrModel.swift in Sources */,
 				43D890BC1A891EBA009C9F40 /* B68UIFloatLabelTextField.swift in Sources */,
 				43BBDF9A1A642D850006B61F /* BTDiscovery.swift in Sources */,
@@ -837,7 +723,7 @@
 				435C921C1A6F9C9B00807847 /* TransmitterData.swift in Sources */,
 				434534AA1A751E70000D591E /* BGReading.swift in Sources */,
 				1DD153611A8193CA003E7CFD /* NightscoutUploader.swift in Sources */,
-				1D7B186D1ABCCBD500DD1632 /* _FailedUpload.swift in Sources */,
+				1DCAA6641ABF4ECA00A3F2CC /* FailedUpload.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -845,16 +731,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43CFB7E41AB73D8700C70423 /* TestRawData.swift in Sources */,
-				43CFB7DB1AB73D7700C70423 /* EulaViewController.swift in Sources */,
-				43CFB7D91AB73D7700C70423 /* AddBGReadingViewController.swift in Sources */,
-				43CFB7D21AB73D4E00C70423 /* AppDelegate.swift in Sources */,
-				43CFB7D81AB73D7700C70423 /* StartSensorViewController.swift in Sources */,
-				1D7B188F1ABD30F500DD1632 /* ChartViewController.swift in Sources */,
-				43E5363C1A62CE480037EED0 /* DxtrTests.swift in Sources */,
-				43CFB7DA1AB73D7700C70423 /* AddDoubleCalibrationViewController.swift in Sources */,
-				43CFB7D51AB73D6E00C70423 /* BTService.swift in Sources */,
-				43CFB7E31AB73D7D00C70423 /* TransmitterData.swift in Sources */,
 				43CFB7E41AB73D8700C70423 /* TestRawData.swift in Sources */,
 				43CFB7F21AB76E5D00C70423 /* SensorTests.swift in Sources */,
 				43CFB7DB1AB73D7700C70423 /* EulaViewController.swift in Sources */,
@@ -864,27 +740,25 @@
 				43E5363C1A62CE480037EED0 /* DxtrTests.swift in Sources */,
 				43CFB7DA1AB73D7700C70423 /* AddDoubleCalibrationViewController.swift in Sources */,
 				43CFB7D51AB73D6E00C70423 /* BTService.swift in Sources */,
+				1DCAA66B1ABF4EEF00A3F2CC /* StateManager.swift in Sources */,
 				43CFB7E31AB73D7D00C70423 /* TransmitterData.swift in Sources */,
 				43CFB8141AB8C05300C70423 /* SwiftOverlays.swift in Sources */,
 				43CFB7DE1AB73D7D00C70423 /* _Sensor.swift in Sources */,
 				43CFB7DD1AB73D7D00C70423 /* _Calibration.swift in Sources */,
 				43CFB7D41AB73D6A00C70423 /* BTDiscovery.swift in Sources */,
 				43CFB7E11AB73D7D00C70423 /* Calibration.swift in Sources */,
-				1D7B188D1ABD30E100DD1632 /* _FailedUpload.swift in Sources */,
-				1D7B188E1ABD30E800DD1632 /* SettingsManager.swift in Sources */,
-				43CFB7CC1AB73D4900C70423 /* Constants.swift in Sources */,
-				1D7B18921ABE88A000DD1632 /* StateManager.swift in Sources */,
-				43CFB7DC1AB73D7D00C70423 /* _BGReading.swift in Sources */,
-				1D7B188C1ABD30DD00DD1632 /* FailedUpload.swift in Sources */,
 				43CFB7CC1AB73D4900C70423 /* Constants.swift in Sources */,
 				43CFB7DC1AB73D7D00C70423 /* _BGReading.swift in Sources */,
 				43CFB7E21AB73D7D00C70423 /* Sensor.swift in Sources */,
 				43CFB7D71AB73D7700C70423 /* MasterViewController.swift in Sources */,
+				1DCAA6631ABF4ECA00A3F2CC /* _FailedUpload.swift in Sources */,
+				1DCAA65F1ABF4EB000A3F2CC /* ChartViewController.swift in Sources */,
+				1DCAA6651ABF4ECA00A3F2CC /* FailedUpload.swift in Sources */,
 				43CFB7E01AB73D7D00C70423 /* BGReading.swift in Sources */,
 				43CFB7E91AB73DAB00C70423 /* B68UIFloatLabelTextField.swift in Sources */,
+				1DCAA6691ABF4EEF00A3F2CC /* SettingsManager.swift in Sources */,
 				43CFB7DF1AB73D7D00C70423 /* _TransmitterData.swift in Sources */,
 				43CFB7D61AB73D7200C70423 /* NightscoutUploader.swift in Sources */,
-				43CFB7EA1AB73DB400C70423 /* SwiftOverlays.swift in Sources */,
 				43CFB7E51AB73D9300C70423 /* DxtrModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -892,11 +766,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1D7B188A1ABD2F7700DD1632 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "XCGLogger (iOS)";
-			targetProxy = 1D7B18891ABD2F7700DD1632 /* PBXContainerItemProxy */;
-			targetProxy = 1D8834161AAD4F5B00DA685B /* PBXContainerItemProxy */;
 		4304DFCB1ABC879400856AD8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "XCGLogger (iOS)";
@@ -1014,7 +883,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iOS Development: Rick Friele (27AN9EGDF9)";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = Dxtr/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
@@ -1031,7 +899,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iOS Distribution: Rick Friele";
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = Dxtr/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;

--- a/Dxtr/Info.plist
+++ b/Dxtr/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>520</string>
+	<string>523</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIBackgroundModes</key>


### PR DESCRIPTION
Running pod update gave the following error before:

/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0/lib/cocoapods/user_interface/error_report.rb:13:in `report': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
    from /Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0/lib/cocoapods/command.rb:59:in`report_error'
    from /Library/Ruby/Gems/2.0.0/gems/claide-0.8.1/lib/claide/command.rb:374:in `handle_exception'
    from /Library/Ruby/Gems/2.0.0/gems/claide-0.8.1/lib/claide/command.rb:315:in`rescue in run'
    from /Library/Ruby/Gems/2.0.0/gems/claide-0.8.1/lib/claide/command.rb:303:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0/lib/cocoapods/command.rb:46:in`run'
    from /Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0/bin/pod:44:in `<top (required)>'
    from /usr/bin/pod:23:in`load'
    from /usr/bin/pod:23:in `<main>'

Seems to be related to an invalid character, possibly '`' in the project file
