### PR TITLE
Podfile changes for Swift 1.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,8 +4,8 @@ link_with 'Dxtr', 'DxtrTests'
 
 use_frameworks!
 
-pod 'QueryKit/Swift', '~> 0.9.2', :git => 'https://github.com/QueryKit/QueryKit'
-pod 'Alamofire', '~> 1.1'
-pod 'CryptoSwift', '~> 0.0'
+pod 'QueryKit/Swift', :git => 'https://github.com/QueryKit/QueryKit', :tag => "swift-1.2"
+pod 'Alamofire', '~> 1.2'
+pod 'CryptoSwift', '~> 0.0.10'
 
 use_frameworks!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,30 +1,31 @@
 PODS:
-  - Alamofire (1.1.4)
-  - CryptoSwift (0.0.8)
-  - QueryKit/Attribute/Swift (0.9.2):
+  - Alamofire (1.2.2)
+  - CryptoSwift (0.0.10)
+  - QueryKit/Attribute/Swift (0.9.1):
     - QueryKit/QuerySet/Swift
-  - QueryKit/QuerySet/Swift (0.9.2)
-  - QueryKit/Swift (0.9.2):
+  - QueryKit/QuerySet/Swift (0.9.1)
+  - QueryKit/Swift (0.9.1):
     - QueryKit/Attribute/Swift
     - QueryKit/QuerySet/Swift
 
 DEPENDENCIES:
-  - Alamofire (~> 1.1)
-  - CryptoSwift (~> 0.0)
-  - QueryKit/Swift (from `https://github.com/QueryKit/QueryKit`)
+  - Alamofire (~> 1.2)
+  - CryptoSwift (~> 0.0.10)
+  - QueryKit/Swift (from `https://github.com/QueryKit/QueryKit`, tag `swift-1.2`)
 
 EXTERNAL SOURCES:
   QueryKit:
     :git: https://github.com/QueryKit/QueryKit
+    :tag: swift-1.2
 
 CHECKOUT OPTIONS:
   QueryKit:
-    :commit: c3b309271b4572b845c0248957d45870229d8626
     :git: https://github.com/QueryKit/QueryKit
+    :tag: swift-1.2
 
 SPEC CHECKSUMS:
-  Alamofire: 6a2cbaebe78a6d469bc55ee37f0a24ba22af76ac
-  CryptoSwift: 6d1b93af5b48e02e57366bfad28b00170af405ee
-  QueryKit: fb44b555d4c0f6942a2fe49395fe0229f6f0d08c
+  Alamofire: 11a6022f5089887d92ffb5a3014c97a0a915ab98
+  CryptoSwift: 3b886d001f50deb65623a8967d68f6b8bf8d9ba1
+  QueryKit: 7e11bce924368eb670e4079f49ca062b0938eb6b
 
-COCOAPODS: 0.36.0
+COCOAPODS: 0.37.1


### PR DESCRIPTION
Update Alamofire, CryptoSwift, and QueryKit to Swift 1.2 compatible versions for building on Xcode 6.3
